### PR TITLE
Added some revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 rOpenSci Onboarding
 ===================
 
+Thank you for considering submitting your package to the rOpenSci suite. In order to ensure a consistent level of software quality for our users, we ask that you go through an onboarding process so we can better understand what your software does, and how we can help improve it before adding it to our suite. This process also allows us to ensure that your package meets our guidelines and provides opportunity for discussion where exceptions are requested.
 
-## Initial submission steps
+## How to begin the onboarding process
 
-* [Open an issue](https://github.com/ropensci/onboarding) in this repository
-* Copy the following into the issue and answer the following in brief:
-    * Describe the package
+* Begin by [opening a new issue](https://github.com/ropensci/onboarding).
+* 
+* Copy the following template into the issue and answer as concisely as possible:
+
+```
+    * Concise package description:
     * What data source(s) does it work with (if applicable)?
     * Who is the target audience?
     * Who has/will contribute to this package?
     * Are you willing to follow the rOpenSci policies (link), including transferring your repo to the rOpenSci GitHub organization account?
     * Are you willing to follow the [rOpenSci packaging guidelines](https://github.com/ropensci/packaging_guide? If you have disagreements with them, explain.
-* Submit the issue
-* We'll look over the issue and start a conversation with you.
-* If we agree to accept the package, we'll have you transfer your GitHub repository if on GitHub, or import from another platform, or start a new repository.
+```
 
-## After acceptance
+* Once you have completed the template, submit the issue. Someone from our team will take a look within 1-2 business days and respond with next steps.  Once your package is approved, we will provide further instructions on transferring your repository to the rOpenSci organizational account.
 
-* Hook up your package with continuous integration, and into our Slack instance
-* List your package in our packages list at [ropensci.org/packages](http://ropensci.org/packages/)
-* List you on our community page (if not already there) [ropensci.org/community](http://ropensci.org/community/#community)
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Thank you for considering submitting your package to the rOpenSci suite. In orde
 
 ## How to begin the onboarding process
 
-* Begin by [opening a new issue](https://github.com/ropensci/onboarding).
+* Begin by [opening a new issue](https://github.com/ropensci/onboarding/issues/new).
 * 
 * Copy the following template into the issue and answer as concisely as possible:
 


### PR DESCRIPTION
- Made it more concise.
- Removed notes on Slack/community page etc as those are secondary steps we don't need in the README. We can keep those in another md file and link to it as an issue comes to a close. Keeps instructions simple and clean.

TODO
- The template that they copy into an issue needs revising