### PR TITLE
Harmonizing onboarding with JOSS

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,136 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, echo = FALSE, message=FALSE, warning=FALSE}
+library(airtabler)
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "README-"
+)
+```
+
+# rOpenSci Onboarding 
+
+Thank you for considering submitting your package to the rOpenSci suite. All
+our packages go through a process of [open peer review](https://ropensci.org/blog/2016/03/28/software-review) to ensure a consistent level of quality
+for our users. This process also allows us to ensure that your package meets
+our guidelines and provides opportunity for discussion where exceptions are
+requested.
+
+* [Why submit your package to rOpenSci?](#why-submit)
+* [Why review for rOpenSci?](#why-review)
+* [How to submit your package](#how-submit)
+* [Useful documents in this repository](#files)
+* [Editors and reviewers](#editors)
+
+# <a href="#why-submit" name="why-submit"></a>Why submit your package to rOpenSci?
+
+-   First, and foremost, we hope you submit your package for review **because you
+    value the feedback**.  We aim to provide useful feedback to package authors
+    and for [our review process] to be open, non-adversarial, and focused on
+    improving software quality.
+-   Once aboard, your package will continue to recieve **support from rOpenSci
+    members**.  You'll retain ownership  and control of of your package, but we
+    can help with ongoing maintenance issues such as those associated with
+    updates to R and dependencies and CRAN policies.
+-   rOpenSci will **promote your package** through our [web 
+    page](https://ropensci.org/packages/), [blog](https://ropensci.org/blog/),
+    and [social media](https://twitter.com/ropensci).  Packages in our suite
+    are also distributed via our [drat repository](http://packages.ropensci.org/)
+    and [Docker images](https://hub.docker.com/r/rocker/ropensci/), and listed
+    in our [task views](https://github.com/search?utf8=%E2%9C%93&q=user%3Aropensci+%22task+view%22&type=Repositories&ref=searchresults).
+-   rOpenSci **packages can be cross-listed** with other repositories such as CRAN
+    and BioConductor.
+-   rOpenSci packages that contain a short accomanying paper can, after review,
+    be automatically submitted to the
+    [Journal of Open-Source Software](http://joss.theoj.org/) for fast-tracked
+    publication.
+    
+## <a href="#why-review" name="why-review"></a>Why review packages for rOpenSci?
+
+-   As in any peer-review process, we hope you choose to review **to give back
+    to the rOpenSci and scientific communities.**  Our mission to expand
+    access to scientific data and promote a culture of reproducible research
+    is only possible through the volunteer efforts of community members like you.
+-   Review is a two-way conversation. By reviewing packages, you'll have the
+    chance to **continue to learn development practices from authors and
+    other reviewers**.  
+-   The open nature of our review process allows you to **network and meet
+    colleagues and collaborators** through the review process.  Our community
+    is friendly and filled with supportive members expert in R development and
+    many other areas of science and scientific computing.
+-   To volunteer to be one of our reviewers, please e-mail us at info@ropensci.org
+    or contact us on Twitter at [@rOpenSci](https://twitter.com/rOpenSci). We
+    are always looking for more reviewers with both general package-writing experience
+    and domain expertise in the fields packages are used for.
+    
+# <a href="#how-submit" name="how-submit"></a>How to submit your package for review
+
+-   Consult our [policies](policies.md) see if your package meets our
+    criteria for fitting into our suite and not overlapping with other packages.
+    -    If you are unsure whether a package meets our criteria, feel free to open
+         an issue as a pre-submission inquiry to ask if the package is appropriate.
+-   Follow our [packaging style guide](packaging_guide.md) to ensure your package
+  meets our style and quality criteria. 
+    -   If you would like your package also submitted to
+        [Journal of Open-Source Software](http://joss.theoj.org/), it should include a `paper.md`
+        file describing the package. More detail on JOSS's requirements can be found [at their website](http://joss.theoj.org/about#author_guidelines).
+-   Next, [open a new issue](https://github.com/ropensci/onboarding/issues/new) in
+this repository and fill out the template.
+-   An [editor](#editors) will review your submission within 5 business 
+    days and respond with next steps. The editor may assign the package to
+    reviewers, request that the package be updated to meet minimal criteria
+    before review, or reject the package due to lack of fit or overlap.
+-   If your package meets minimal criteria, the editor will assign  1-3 reviewers.
+    They will be asked to provide reviews as comments on your issue within 3 weeks.
+-   We ask that you respond to reviewers' comments within 2 weeks of the 
+    last-submitted review, but you may make updates to your package or respond
+    at any time.  We encourage ongoing conversations between authors and
+    reviewers. See the [reviewing guide](reviewing_guide.md) for more details.
+-   Once your package is approved, we will provide further instructions on
+    transferring your repository to the rOpenSci repository.
+
+Our [code of conduct](policies.md/#code-of-conduct) is mandatory for everyone
+involved in our review process.
+
+Our review process is always in development, and we encourage feedback and discussion
+on how to improve the process on our [forum](https://discuss.ropensci.org/).
+
+# <a href="#editors" name="editors"></a> Useful documents in this repository
+
+- [`policies.md`](policies.md) - policies as to what packages to accept and how to conduct the review process
+- [`reviewing_guide`](reviewing_guide) - high-level guide for reviewers
+- [`packaging_guide.md`](packaging_guide.md) - detailed requirements and recommendations for rOpenSci packages
+- [`editors_checklist.md`](editors_checklist.md) - steps for editors to take throughout the review process
+- [`reviewer_template.md`](reviewer_template.md) - a template and checklist for reviews
+- [`editor_template.md`](editor_template.md) - a template and checklist for editors' preliminary review
+- [`issue_template.md`](issue_template.md) - automatically-used template and checklist for authors upon submittal
+- [`review_requuest_template.md`](review_requuest_template.md) - template for e-mails to prospective reviewers
+- [`news_template.md`](news_template.md) - a template for authors to use for NEWS files in their packages.
+
+# <a href="#editors" name="editors"></a> Editors and reviewers
+
+### Associate editors
+
+rOpenSci's onboarding process is run by:
+
+* [Noam Ross](https://github.com/noamross), EcoHealth Alliance   
+* [Scott Chamberlain](https://github.com/sckott), rOpenSci  
+* [Karthik Ram](https://github.com/karthik), rOpenSci  
+
+We are grateful to the following individuals who have offered up their time and expertise to review packages submitted to rOpenSci.
+
+```{r reviewers, echo=FALSE, results='asis'}
+editors <- c("Noam Ross", "Scott Chamberlain", "Karthik Ram")
+reviewers <- airtable(base = "appZIB8hgtvjoV99D", tables = "Reviewers")$Reviewers$get()
+reviewers <- reviewers[!is.null(reviewers$Reviews) & !(reviewers$name %in% editors), ]
+reviewers <- reviewers[order(reviewers$name), ]
+cat(paste0("-   [", reviewers$name, "](https://github.com/", reviewers$github, ")", collapse = "\n"))
+```
+
+
+[![repo_banner](http://ropensci.org/assets/ropensci_repo_banner.png)](http://ropensci.org)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ requested.
     in our [task views](https://github.com/search?utf8=%E2%9C%93&q=user%3Aropensci+%22task+view%22&type=Repositories&ref=searchresults).
 -   rOpenSci **packages can be cross-listed** with other repositories such as CRAN
     and BioConductor.
+-   rOpenSci packages that contain a short accomanying paper can, after review,
+    be automatically submitted to the
+    [Journal of Open-Source Software](http://joss.theoj.org/) for fast-tracked
+    publication.
     
 ## <a href="#why-review" name="why-review"></a>Why review packages for rOpenSci?
 
@@ -45,7 +49,9 @@ requested.
     is friendly and filled with supportive members expert in R development and
     many other areas of science and scientific computing.
 -   To volunteer to be one of our reviewers, please e-mail us at info@ropensci.org
-    or contact us on Twitter at [@rOpenSci](https://twitter.com/rOpenSci).
+    or contact us on Twitter at [@rOpenSci](https://twitter.com/rOpenSci). We
+    are always looking for more reviewers with both general package-writing experience
+    and domain expertise in the fields packages are used for.
     
 # <a href="#how-submit" name="how-submit"></a>How to submit your package for review
 
@@ -53,6 +59,9 @@ requested.
     criteria for fitting into our suite and not overlapping with other packages.
 -   Follow our [packaging style guide](packaging_guide.md) to ensure your package
   meets our style and quality criteria. 
+    -   If you would like your package also submitted to
+        [Journal of Open-Source Software](http://joss.theoj.org/), it should a `paper.md`
+        file describing the package. JOSS's requirements [here](http://joss.theoj.org/about#author_guidelines).
 -   Next, [open a new issue](https://github.com/ropensci/onboarding/issues/new) in
 this repository and fill out the template.
 -   An [editor](#editors) will review your submission within 5 business 

--- a/README.md
+++ b/README.md
@@ -1,119 +1,104 @@
-![packaging](packaging.png) rOpenSci Onboarding 
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+rOpenSci Onboarding
 ===================
 
-Thank you for considering submitting your package to the rOpenSci suite. All
-our packages go through a process of [open peer review](https://ropensci.org/blog/2016/03/28/software-review) to ensure a consistent level of quality
-for our users. This process also allows us to ensure that your package meets
-our guidelines and provides opportunity for discussion where exceptions are
-requested.
+Thank you for considering submitting your package to the rOpenSci suite. All our packages go through a process of [open peer review](https://ropensci.org/blog/2016/03/28/software-review) to ensure a consistent level of quality for our users. This process also allows us to ensure that your package meets our guidelines and provides opportunity for discussion where exceptions are requested.
 
-* [Why submit your package to rOpenSci?](#why-submit)
-* [Why review for rOpenSci?](#why-review)
-* [How to submit your package](#how-submit)
-* [Editors](#editors)
+-   [Why submit your package to rOpenSci?](#why-submit)
+-   [Why review for rOpenSci?](#why-review)
+-   [How to submit your package](#how-submit)
+-   [Useful documents in this repository](#files)
+-   [Editors and reviewers](#editors)
 
-# <a href="#why-submit" name="why-submit"></a>Why submit your package to rOpenSci?
+<a href="#why-submit" name="why-submit"></a>Why submit your package to rOpenSci?
+================================================================================
 
--   First, and foremost, we hope you submit your package for review **because you
-    value the feedback**.  We aim to provide useful feedback to package authors
-    and for [our review process] to be open, non-adversarial, and focused on
-    improving software quality.
--   Once aboard, your package will continue to recieve **support from rOpenSci
-    members**.  You'll retain ownership  and control of of your package, but we
-    can help with ongoing maintenance issues such as those associated with
-    updates to R and dependencies and CRAN policies.
--   rOpenSci will **promote your package** through our [web 
-    page](https://ropensci.org/packages/), [blog](https://ropensci.org/blog/),
-    and [social media](https://twitter.com/ropensci).  Packages in our suite
-    are also distributed via our [drat repository](http://packages.ropensci.org/)
-    and [Docker images](https://hub.docker.com/r/rocker/ropensci/), and listed
-    in our [task views](https://github.com/search?utf8=%E2%9C%93&q=user%3Aropensci+%22task+view%22&type=Repositories&ref=searchresults).
--   rOpenSci **packages can be cross-listed** with other repositories such as CRAN
-    and BioConductor.
--   rOpenSci packages that contain a short accomanying paper can, after review,
-    be automatically submitted to the
-    [Journal of Open-Source Software](http://joss.theoj.org/) for fast-tracked
-    publication.
-    
-## <a href="#why-review" name="why-review"></a>Why review packages for rOpenSci?
+-   First, and foremost, we hope you submit your package for review **because you value the feedback**. We aim to provide useful feedback to package authors and for \[our review process\] to be open, non-adversarial, and focused on improving software quality.
+-   Once aboard, your package will continue to recieve **support from rOpenSci members**. You'll retain ownership and control of of your package, but we can help with ongoing maintenance issues such as those associated with updates to R and dependencies and CRAN policies.
+-   rOpenSci will **promote your package** through our [web page](https://ropensci.org/packages/), [blog](https://ropensci.org/blog/), and [social media](https://twitter.com/ropensci). Packages in our suite are also distributed via our [drat repository](http://packages.ropensci.org/) and [Docker images](https://hub.docker.com/r/rocker/ropensci/), and listed in our [task views](https://github.com/search?utf8=%E2%9C%93&q=user%3Aropensci+%22task+view%22&type=Repositories&ref=searchresults).
+-   rOpenSci **packages can be cross-listed** with other repositories such as CRAN and BioConductor.
+-   rOpenSci packages that contain a short accomanying paper can, after review, be automatically submitted to the [Journal of Open-Source Software](http://joss.theoj.org/) for fast-tracked publication.
 
--   As in any peer-review process, we hope you choose to review **to give back
-    to the rOpenSci and scientific communities.**  Our mission to expand
-    access to scientific data and promote a culture of reproducible research
-    is only possible through the volunteer efforts of community members like you.
--   Review is a two-way conversation. By reviewing packages, you'll have the
-    chance to **continue to learn development practices from authors and
-    other reviewers**.  
--   The open nature of our review process allows you to **network and meet
-    colleagues and collaborators** through the review process.  Our community
-    is friendly and filled with supportive members expert in R development and
-    many other areas of science and scientific computing.
--   To volunteer to be one of our reviewers, please e-mail us at info@ropensci.org
-    or contact us on Twitter at [@rOpenSci](https://twitter.com/rOpenSci). We
-    are always looking for more reviewers with both general package-writing experience
-    and domain expertise in the fields packages are used for.
-    
-# <a href="#how-submit" name="how-submit"></a>How to submit your package for review
+<a href="#why-review" name="why-review"></a>Why review packages for rOpenSci?
+-----------------------------------------------------------------------------
 
--   Consult our [policies](policies.md) see if your package meets our
-    criteria for fitting into our suite and not overlapping with other packages.
--   Follow our [packaging style guide](packaging_guide.md) to ensure your package
-  meets our style and quality criteria. 
-    -   If you would like your package also submitted to
-        [Journal of Open-Source Software](http://joss.theoj.org/), it should a `paper.md`
-        file describing the package. JOSS's requirements [here](http://joss.theoj.org/about#author_guidelines).
--   Next, [open a new issue](https://github.com/ropensci/onboarding/issues/new) in
-this repository and fill out the template.
--   An [editor](#editors) will review your submission within 5 business 
-    days and respond with next steps. The editor may assign the package to
-    reviewers, request that the package be updated to meet minimal criteria
-    before review, or reject the package due to lack of fit or overlap.
--   If your package meets minimal criteria, the editor will assign  1-3 reviewers.
-    They will be asked to provide reviews as comments on your issue within 3 weeks.
--   We ask that you respond to reviewers' comments within 2 weeks of the 
-    last-submitted review, but you may make updates to your package or respond
-    at any time.  We encourage ongoing conversations between authors and
-    reviewers. See the [reviewing guide](reviewing_guide.md) for more details.
--   Once your package is approved, we will provide further instructions on
-    transferring your repository to the rOpenSci repository.
+-   As in any peer-review process, we hope you choose to review **to give back to the rOpenSci and scientific communities.** Our mission to expand access to scientific data and promote a culture of reproducible research is only possible through the volunteer efforts of community members like you.
+-   Review is a two-way conversation. By reviewing packages, you'll have the chance to **continue to learn development practices from authors and other reviewers**.
+-   The open nature of our review process allows you to **network and meet colleagues and collaborators** through the review process. Our community is friendly and filled with supportive members expert in R development and many other areas of science and scientific computing.
+-   To volunteer to be one of our reviewers, please e-mail us at <info@ropensci.org> or contact us on Twitter at \[@rOpenSci\](<https://twitter.com/rOpenSci>). We are always looking for more reviewers with both general package-writing experience and domain expertise in the fields packages are used for.
 
-Our [code of conduct](policies.md/#code-of-conduct) is mandatory for everyone
-involved in our review process.
+<a href="#how-submit" name="how-submit"></a>How to submit your package for review
+=================================================================================
 
-Our review process is always in development, and we encourage feedback and discussion
-on how to improve the process on our [forum](https://discuss.ropensci.org/).
+-   Consult our [policies](policies.md) see if your package meets our criteria for fitting into our suite and not overlapping with other packages.
+    -   If you are unsure whether a package meets our criteria, feel free to open an issue as a pre-submission inquiry to ask if the package is appropriate.
+-   Follow our [packaging style guide](packaging_guide.md) to ensure your package meets our style and quality criteria.
+    -   If you would like your package also submitted to [Journal of Open-Source Software](http://joss.theoj.org/), it should include a `paper.md` file describing the package. More detail on JOSS's requirements can be found [at their website](http://joss.theoj.org/about#author_guidelines).
+-   Next, [open a new issue](https://github.com/ropensci/onboarding/issues/new) in this repository and fill out the template.
+-   An [editor](#editors) will review your submission within 5 business days and respond with next steps. The editor may assign the package to reviewers, request that the package be updated to meet minimal criteria before review, or reject the package due to lack of fit or overlap.
+-   If your package meets minimal criteria, the editor will assign 1-3 reviewers. They will be asked to provide reviews as comments on your issue within 3 weeks.
+-   We ask that you respond to reviewers' comments within 2 weeks of the last-submitted review, but you may make updates to your package or respond at any time. We encourage ongoing conversations between authors and reviewers. See the [reviewing guide](reviewing_guide.md) for more details.
+-   Once your package is approved, we will provide further instructions on transferring your repository to the rOpenSci repository.
 
-# <a href="#editors" name="editors"></a> Editors
+Our [code of conduct](policies.md/#code-of-conduct) is mandatory for everyone involved in our review process.
+
+Our review process is always in development, and we encourage feedback and discussion on how to improve the process on our [forum](https://discuss.ropensci.org/).
+
+<a href="#editors" name="editors"></a> Useful documents in this repository
+==========================================================================
+
+-   [`policies.md`](policies.md) - policies as to what packages to accept and how to conduct the review process
+-   [`reviewing_guide`](reviewing_guide) - high-level guide for reviewers
+-   [`packaging_guide.md`](packaging_guide.md) - detailed requirements and recommendations for rOpenSci packages
+-   [`editors_checklist.md`](editors_checklist.md) - steps for editors to take throughout the review process
+-   [`reviewer_template.md`](reviewer_template.md) - a template and checklist for reviews
+-   [`editor_template.md`](editor_template.md) - a template and checklist for editors' preliminary review
+-   [`issue_template.md`](issue_template.md) - automatically-used template and checklist for authors upon submittal
+-   [`review_requuest_template.md`](review_requuest_template.md) - template for e-mails to prospective reviewers
+-   [`news_template.md`](news_template.md) - a template for authors to use for NEWS files in their packages.
+
+<a href="#editors" name="editors"></a> Editors and reviewers
+============================================================
 
 ### Associate editors
 
-* [Noam Ross](https://github.com/noamross), EcoHealth Alliance.   
-* [Scott Chamberlain](https://github.com/sckott), rOpenSci  
-* [Karthik Ram](https://github.com/karthik), rOpenSci  
+rOpenSci's onboarding process is run by:
 
-### Review board
+-   [Noam Ross](https://github.com/noamross), EcoHealth Alliance
+-   [Scott Chamberlain](https://github.com/sckott), rOpenSci
+-   [Karthik Ram](https://github.com/karthik), rOpenSci
 
 We are grateful to the following individuals who have offered up their time and expertise to review packages submitted to rOpenSci.
 
- - [Andrew MacDonald](https://github.com/aammd)
- - [Andy Teucher](https://github.com/ateucher)
- - [Bob Rudis](https://github.com/hrbrmstr)
- - [Dean Attali](https://github.com/daattali)
- - [Jeff Hollister](https://github.com/jhollist)
- - [Jeroen Ooms](https://github.com/jeroenooms)
- - [Julia Gustavsen](https://github.com/joolia)
- - [Julia Silge](https://github.com/juliasilge)
- - [Kevin Ushey](https://github.com/kevinushey)
- - [Lauren Yamane](https://github.com/layamane)
- - [Lincoln Mullen](https://github.com/lmullen)
- - [Mine Cetinkaya-Rundel](https://github.com/mine-cetinkaya-rundel)
- - [Maëlle Salmon](https://github.com/masalmon)
- - [Oliver Keyes](https://github.com/Ironholds)
- - [Remko Duursma](https://github.com/RemkoDuursma)
- - [Rich FitzJohn](https://github.com/richfitz)
- - [Robin Lovelace](https://github.com/Robinlovelace)
- - [Stefan Widgren](https://github.com/stewid)
- - [Toph Allen](https://github.com/toph-allen)
- - [Stefan Widgren](https://github.com/stewid)
+-   [Andee Kaplan](https://github.com/NA)
+-   [Andrew MacDonald](https://github.com/aammd)
+-   [Andy Teucher](https://github.com/ateucher)
+-   [Bob Rudis](https://github.com/hrbrmstr)
+-   [Brooke Anderson](https://github.com/geanders)
+-   [Daniel Emaasit](https://github.com/Emaasit)
+-   [David Gohel](https://github.com/davidgohel)
+-   [David Winter](https://github.com/dwinter)
+-   [Dean Attali](https://github.com/daattali)
+-   [Dillon Niederhut](https://github.com/deniederhut)
+-   [Dirk Schumacher](https://github.com/dirkschumacher)
+-   [Hilary Parker](https://github.com/hilaryparker)
+-   [Jason Becker](https://github.com/jsonbecker)
+-   [Jeff Hollister](https://github.com/jhollist)
+-   [Jeroen Ooms](https://github.com/jeroenooms)
+-   [Julia Gustavsen](https://github.com/joolia)
+-   [Julia Silge](https://github.com/juliasilge)
+-   [Kevin Ushey](https://github.com/kevinushey)
+-   [Lauren Yamane](https://github.com/layamane)
+-   [Lincoln Mullen](https://github.com/lmullen)
+-   [Maëlle Salmon](https://github.com/masalmon)
+-   [Michael Sumner](https://github.com/mdsumner)
+-   [Oliver Keyes](https://github.com/Ironholds)
+-   [Remko Duursma](https://github.com/RemkoDuursma)
+-   [Rich FitzJohn](https://github.com/richfitz)
+-   [Robin Lovelace](https://github.com/Robinlovelace)
+-   [Stefan Widgren](https://github.com/stewid)
+-   [Tiffany Timbers](https://github.com/ttimbers)
+-   [Toph Allen](https://github.com/toph-allen)
 
-[![repo_banner](http://ropensci.org/assets/ropensci_repo_banner.png)](http://ropensci.org)
+[![repo\_banner](http://ropensci.org/assets/ropensci_repo_banner.png)](http://ropensci.org)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ requested.
     colleagues and collaborators** through the review process.  Our community
     is friendly and filled with supportive members expert in R development and
     many other areas of science and scientific computing.
+-   To volunteer to be one of our reviewers, please e-mail us at info@ropensci.org
+-   or contact us on Twitter at [@rOpenSci](https://twitter.com/rOpenSci).
     
 # <a href="#how-submit" name="how-submit"></a>How to submit your package for review
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ requested.
     is friendly and filled with supportive members expert in R development and
     many other areas of science and scientific computing.
 -   To volunteer to be one of our reviewers, please e-mail us at info@ropensci.org
--   or contact us on Twitter at [@rOpenSci](https://twitter.com/rOpenSci).
+    or contact us on Twitter at [@rOpenSci](https://twitter.com/rOpenSci).
     
 # <a href="#how-submit" name="how-submit"></a>How to submit your package for review
 

--- a/cran_gotchas.md
+++ b/cran_gotchas.md
@@ -1,7 +1,0 @@
-This is a collection of CRAN gotchas that are worth avoiding at the outset.
-
-* Make sure your package title is in Title Case.
-* Do not put a period on the end of your title
-* Avoid starting the description with the package name or This package ...
-* Make sure you include links to websites if you wrap a web API, scrape data from a site, etc. in the `Description` field of your `DESCRIPTION` file
-* Avoid long running tests and examples.  Consider `testthat::skip_on_cran` in tests to skip things that take a long time but still test them locally and on Travis.

--- a/editor_template.md
+++ b/editor_template.md
@@ -2,7 +2,7 @@
 
 - [ ] **Fit**: The package meets or criteria [fit](policies.md#fit) and [overlap](policies.md#fit)
 - [ ] **Automated tests:** Package has a testing suite and is tested via Travis-CI or another CI service.
-- [ ] **License:** The package has a CRAN accepted license
+- [ ] **License:** The package has a CRAN or OSI accepted license
 - [ ] **Repository:** The repository link resolves correctly
 - [ ] **Archive** (JOSS only, may be post-review): The repository DOI resolves correctly
 - [ ] **Version** (JOSS only, may be post-review): Does the release version given match the GitHub release (v1.0.0)?

--- a/editor_template.md
+++ b/editor_template.md
@@ -1,4 +1,4 @@
-# Editor checks:
+### Editor checks:
 
 - [ ] **Fit**: The package meets or criteria [fit](policies.md#fit) and [overlap](policies.md#fit)
 - [ ] **Automated tests:** Package has a testing suite and is tested via Travis-CI or another CI service.
@@ -9,7 +9,7 @@
 
 ---
 
-# Editor comments
+#### Editor comments
 
 ---
 

--- a/editor_template.md
+++ b/editor_template.md
@@ -3,7 +3,7 @@
 - [ ] **Fit**: The package meets or criteria [fit](policies.md#fit) and [overlap](policies.md#fit)
 - [ ] **Automated tests:** Package has a testing suite and is tested via Travis-CI or another CI service.
 - [ ] **License:** The package has a CRAN accepted license
-- [ ] **Repository:** The repository link resolives correctly
+- [ ] **Repository:** The repository link resolves correctly
 - [ ] **Archive** (JOSS only, may be post-review): The repository DOI resolves correctly
 - [ ] **Version** (JOSS only, may be post-review): Does the release version given match the GitHub release (v1.0.0)?
 

--- a/editor_template.md
+++ b/editor_template.md
@@ -1,0 +1,17 @@
+# Editor checks:
+
+- [ ] **Fit**: The package meets or criteria [fit](policies.md#fit) and [overlap](policies.md#fit)
+- [ ] **Automated tests:** Package has a testing suite and is tested via Travis-CI or another CI service.
+- [ ] **License:** The package has a CRAN accepted license
+- [ ] **Repository:** The repository link resolives correctly
+- [ ] **Archive** (JOSS only, may be post-review): The repository DOI resolves correctly
+- [ ] **Version** (JOSS only, may be post-review): Does the release version given match the GitHub release (v1.0.0)?
+
+---
+
+# Editor comments
+
+---
+
+Reviewers:
+Due date:

--- a/editors_checklist.md
+++ b/editors_checklist.md
@@ -31,9 +31,7 @@ After review:
 -   Add review/er information to the review database (work-in-progress)
 -   If authors intend to submit to CRAN, check against CRAN gotchas and provide
     support through this process.
--   If packages work with an unstable API or are expected to have significant
-    additions post-review, they should be migrated to `ropenscilabs`. Otherwise,
-    they should me be migrated to `ropensci`.
+-   Ask authors to miigrate to `ropenscilabs`. (Tranfer to `ropensci` will take place later).
 -   Add rOpenSci footer to README.  
 -   Close issue and mark with tag `approved`.
 -   Do appropriate promotion for package, which may include:

--- a/issue_template.md
+++ b/issue_template.md
@@ -30,7 +30,7 @@ Confirm each of the following by checking the box.  This package:
 #### Publication options
 
 - [ ] Do you intend for this package to go on CRAN?  
-- [ ] Do you wish to automatically submit to the [Journal of Open Source Software](http://joss.theoj.org/)?
+- [ ] Do you wish to automatically submit to the [Journal of Open Source Software](http://joss.theoj.org/)? If so:
     - [ ] The package contains a [`paper.md`](http://joss.theoj.org/about#paper_structure) with a high-level description.
     - [ ] The package is deposited in a long-term repository with the DOI: 
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -20,12 +20,12 @@
 Confirm each of the following by checking the box.  This package:
 
 - [ ] does not violate the Terms of Service of any service it interacts with. 
-- [ ] only exports functions to the NAMESPACE that are intended for end users
-- [ ] has a test suite
-- [ ] has continuous integration with Travis CI and/or another service  
-- [ ] contains a vignette with examples of its essential functions and uses
-- [ ] contains a README with instructions for installing the development version. 
 - [ ] has a CRAN and OSI accepted license.
+- [ ] contains a README with instructions for installing the development version. 
+- [ ] includes documentation with examples for all functions.
+- [ ] contains a vignette with examples of its essential functions and uses.
+- [ ] has a test suite.
+- [ ] has continuous integration with Travis CI and/or another service.
 
 #### Publication options
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -31,8 +31,8 @@ Confirm each of the following by checking the box.  This package:
 
 - [ ] Do you intend for this package to go on CRAN?  
 - [ ] Do you wish to automatically submit to the [Journal of Open Source Software](http://joss.theoj.org/)?
-- [ ] The package contains a [`paper.md`](http://joss.theoj.org/about#paper_structure) with a high-level description.
-- [ ] The package is deposited in a long-term repository with the DOI: 
+    - [ ] The package contains a [`paper.md`](http://joss.theoj.org/about#paper_structure) with a high-level description.
+    - [ ] The package is deposited in a long-term repository with the DOI: 
 
 #### Detail
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -15,7 +15,7 @@
 
 - [ ] Are there other R packages that accomplish the same thing? If so, what is different about yours?  
 
-#### Requirements
+### Requirements
 
 Confirm each of the following by checking the box.  This package:
 
@@ -34,7 +34,7 @@ Confirm each of the following by checking the box.  This package:
     - [ ] The package contains a [`paper.md`](http://joss.theoj.org/about#paper_structure) with a high-level description.
     - [ ] The package is deposited in a long-term repository with the DOI: 
 
-#### Detail
+### Detail
 
 - [ ] Does `R CMD check` (or `devtools::check()`) succeed?  Paste and describe any errors or warnings:
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -15,7 +15,7 @@
 
 - [ ] Are there other R packages that accomplish the same thing? If so, what is different about yours?  
 
-### Requirements
+#### Requirements
 
 Confirm each of the following by checking the box.  This package:
 
@@ -27,14 +27,14 @@ Confirm each of the following by checking the box.  This package:
 - [ ] contains a README with instructions for installing the development version. 
 - [ ] has a CRAN and OSI accepted license.
 
-### Publication options
+#### Publication options
 
 - [ ] Do you intend for this package to go on CRAN?  
 - [ ] Do you wish to automatically submit to the [Journal of Open Source Software](http://joss.theoj.org/)?
 - [ ] The package contains a [`paper.md`](http://joss.theoj.org/about#paper_structure) with a high-level description.
 - [ ] The package is deposited in a long-term repository with the DOI: 
 
-### Detail
+#### Detail
 
 - [ ] Does `R CMD check` (or `devtools::check()`) succeed?  Paste and describe any errors or warnings:
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,25 +1,43 @@
-* 1. What does this package do? (explain in 50 words or less)  
-* 2. Paste the full DESCRIPTION file inside a code block below.  
+### Summary
+
+- [ ] What does this package do? (explain in 50 words or less):
+
+
+- [ ] Paste the full DESCRIPTION file inside a code block below:
 
 ```
 
 ```
 
-* 3. URL for the package (the development repository, not a stylized html page)  
-* 4. What data source(s) does it work with (if applicable)?  
-* 5. Who is the target audience?  
-* 6. Are there other R packages that accomplish the same thing? If so, what is different about yours?  
-* 7. Check the box next to each policy below, confirming that you agree. These are mandatory.  
-    * [ ] This package does not violate the Terms of Service of any service it interacts with.  
-    * [ ] The repository has continuous integration with Travis CI and/or another service  
-    * [ ] The package contains a vignette  
-    * [ ] The package contains a reasonably complete README with instructions for installing the development version.  
-    * [ ] The package contains unit tests  
-    * [ ] The package only exports functions to the NAMESPACE that are intended for end users  
-* 8. Do you agree to follow the [rOpenSci packaging guidelines](https://github.com/ropensci/packaging_guide)? These aren't mandatory, but we strongly suggest you follow them. If you disagree with anything, please explain.  
-    * [ ] Are there any package dependencies not on CRAN?  
-    * [ ] Do you intend for this package to go on CRAN?  
-    * [ ] Does the package have a CRAN accepted license?    
-    * [ ] Did `R CMD check` (or `devtools::check()`) produce any errors or warnings? If so paste them below.  
-* 9. Please add explanations below for any exceptions to the above:  
-* 10. If this is a resubmission following rejection, please explain the change in circumstances.  
+- [ ] URL for the package (the development repository, not a stylized html page):
+
+- [ ] Who is the target audience?  
+
+- [ ] Are there other R packages that accomplish the same thing? If so, what is different about yours?  
+
+### Requirements
+
+Confirm each of the following by checking the box.  This package:
+
+- [ ] does not violate the Terms of Service of any service it interacts with. 
+- [ ] only exports functions to the NAMESPACE that are intended for end users
+- [ ] has a test suite
+- [ ] has continuous integration with Travis CI and/or another service  
+- [ ] contains a vignette with examples of its essential functions and uses
+- [ ] contains a README with instructions for installing the development version. 
+- [ ] has a CRAN and OSI accepted license.
+
+### Publication options
+
+- [ ] Do you intend for this package to go on CRAN?  
+- [ ] Do you wish to automatically submit to the [Journal of Open Source Software](http://joss.theoj.org/)?
+- [ ] The package contains a [`paper.md`](http://joss.theoj.org/about#paper_structure) with a high-level description.
+- [ ] The package is deposited in a long-term repository with the DOI: 
+
+### Detail
+
+- [ ] Does `R CMD check` (or `devtools::check()`) succeed?  Paste and describe any errors or warnings:
+
+- [ ] Does the package conform to [rOpenSci packaging guidelines](https://github.com/ropensci/packaging_guide)? Please describe any exceptions:
+
+- If this is a resubmission following rejection, please explain the change in circumstances:

--- a/packaging_guide.md
+++ b/packaging_guide.md
@@ -61,13 +61,17 @@ rOpenSci accepts packages that meet our guidelines via a streamlined [onboarding
 
 ## <a href="#docs" name="docs"></a> Documentation
 
+*  All exported functions should have full documentation with examples. 
+
+*  Only functions intended for the end-user should be exported.  Avoid exporting all functions by default.  
+
 * We strongly encourage all submissions to use `roxygen2` for documentation.  `roxygen2` is [an R package](http://cran.r-project.org/web/packages/roxygen2/index.html) that automatically compiles `.Rd` files to your `man` folder in your package from simple tags written above each function.
 
 * More information on using roxygen2 [documentation](http://r-pkgs.had.co.nz/man.html) is available on the R packages book.
 
 * One key advantage of using `roxygen2` is that your `NAMESPACE` will always be automatically generated and up to date.
 
-* Avoid exporting all functions by default. Add `#' @noRd` to internal functions.
+* When using `roxygen2`, add `#' @noRd` to internal functions.
 
 ## <a href="#news" name="news"></a> News
 
@@ -126,7 +130,6 @@ Only include reviewers after asking for their consent.
 
 * Use `Imports` instead of `Depends` for packages providing functions you use internally only. Use `Depends` only if you intend for the user to have functions available from your package dependencies. Make sure to list packages used for testing (`testthat`), and documentation (`knitr`, `roxygen2`) in your `Suggests` section of package dependencies. If you use any packages in your examples sections, make sure to list those, if not already listed elsewhere, in `Enhances` section of package dependencies.
 
-
 ## <a href="#tools" name="tools"></a> Recommended scaffolding
 
 
@@ -139,6 +142,9 @@ Only include reviewers after asking for their consent.
 
 * Use `message()` and `warning()` to communicate with the user in your functions. Please do not use `print()` or `cat()` unless it's for a `print.*()` method, as these methods of printing messages are harder for the user to suppress.
 
+## Miscellaneous
+
+Include files such as `paper.md`, `.travis.yml` in your `.Rbuildignore` file.
 
 ## <a href="#further" name="further"></a> Further guidance
 

--- a/packaging_guide.md
+++ b/packaging_guide.md
@@ -49,9 +49,8 @@ rOpenSci accepts packages that meet our guidelines via a streamlined [onboarding
 
 * We recommend not creating `README.md` directly, but from a `README.Rmd` file (an Rmarkdown file) where possible. The advantage of the `.Rmd` file is you can combine text with code that can be easily updated whenever your package is updated.
 
-* See `devtools::use_readme_rmd()` to get a template for a `README.Rmd` file in your package.
-
-* Consider setting up pre-commit hooks to ensure that `README.md` is always newer than `README.Rmd` (see `devtools::use_git_hook`)
+* Consider using `devtools::use_readme_rmd()` to get a template for a `README.Rmd` file
+and to automatically set up a pre-commit hook to ensure that `README.md` is always newer than `README.Rmd`.
 
 * See the [gistr README](https://github.com/ropensci/gistr#gistr) for a good example README to follow.
 

--- a/packaging_guide.md
+++ b/packaging_guide.md
@@ -156,7 +156,7 @@ This is a collection of CRAN gotchas that are worth avoiding at the outset.
 
 ## <a href="#further" name="further"></a> Further guidance
 
-* The [`devtools` package](https://github.com/hadley/devtools) and its wiki are an excellent resource for in-depth package development help.
+* Hadley Wickham's _R Packages_ is an excellent resource for package development and is available a a [free book on the web](http://r-pkgs.had.co.nz/).
 
 * If you are submitting a package to rOpenSci via the [onboarding repo](https://github.com/ropensci/onboarding), you can direct further questions to the rOpenSci team in the issue tracker, or in our [discussion forum](https://discuss.ropensci.org/).
 

--- a/packaging_guide.md
+++ b/packaging_guide.md
@@ -16,7 +16,9 @@ rOpenSci accepts packages that meet our guidelines via a streamlined [onboarding
 * [Continuous integration](#ci)
 * [Console messages](#messages)
 * [Recommended software scaffolding](#tools)
+* [Miscellaneous CRAN gotchas](#misc)
 * [Further guidance](#further)
+* [Suggestions and Updates](#suggestions)
 
 ## <a href="#pkgnaming" name="pkgnaming"></a> Package naming
 
@@ -141,9 +143,16 @@ Only include reviewers after asking for their consent.
 
 * Use `message()` and `warning()` to communicate with the user in your functions. Please do not use `print()` or `cat()` unless it's for a `print.*()` method, as these methods of printing messages are harder for the user to suppress.
 
-## Miscellaneous
+##  <a href="#misc" name="messages"></a> Miscellaneous
 
-Include files such as `paper.md`, `.travis.yml` in your `.Rbuildignore` file.
+This is a collection of CRAN gotchas that are worth avoiding at the outset.
+
+* Make sure your package title is in Title Case.
+* Do not put a period on the end of your title
+* Avoid starting the description with the package name or This package ...
+* Make sure you include links to websites if you wrap a web API, scrape data from a site, etc. in the `Description` field of your `DESCRIPTION` file
+* Avoid long running tests and examples.  Consider `testthat::skip_on_cran` in tests to skip things that take a long time but still test them locally and on Travis.
+* Include top-level files such as `paper.md`, `.travis.yml` in your `.Rbuildignore` file.
 
 ## <a href="#further" name="further"></a> Further guidance
 
@@ -151,6 +160,6 @@ Include files such as `paper.md`, `.travis.yml` in your `.Rbuildignore` file.
 
 * If you are submitting a package to rOpenSci via the [onboarding repo](https://github.com/ropensci/onboarding), you can direct further questions to the rOpenSci team in the issue tracker, or in our [discussion forum](https://discuss.ropensci.org/).
 
-## Suggestions and updates
+## <a href="#suggestions" name="suggestions"></a> Suggestions and updates
 
-* These packaging guidelines are a work in progress for packages contributed to the rOpenSci suite. Corrections, suggestions and general improvements are welcome on [our issue tracker](https://github.com/ropensci/packaging_guide/issues).
+* These packaging guidelines are a work in progress for packages contributed to the rOpenSci suite. Corrections, suggestions and general improvements are welcome as [issue submissions in this repository](https://github.com/ropensci/onboarding/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Ameta%20). Open discussions are welome in our [forum](https://discuss.ropensci.org/).

--- a/review_request_template.md
+++ b/review_request_template.md
@@ -1,0 +1,28 @@
+# Review request template
+
+Editors may make use of the e-mail template below in recruiting reviewers.
+
+---
+
+Dear [REVIEWER]
+
+Hi, this is [EDITOR]. [FRIENDLY BANTER]. I'm writing to ask if you would be willing to review a package for rOpenSci. As you probably know, rOpenSci conducts peer review of R packages contributed to our collection in a manner similar to journals.
+
+The package, [PACKAGE] by [AUTHOR(S)], does [FUNCTION]. You can find it on GitHub here: [REPO LINK]. We conduct our open review process via GitHub as well, here: [ONBOARDING ISSUE]
+
+If you accept, note that we ask reviewers to complete reviews in three weeks. (We’ve found it takes a similar amount of time to review a package as an academic paper.) 
+
+Our [reviewers guide] details what we look for in a package review, and includes links to example reviews. Our standards are detailed in our [packaging guide], and we provide [reviewer template] for you to use. If you have questions or feedback, feel free to ask me or post to the [rOpenSci forum].
+
+{IF APPLICABLE: The authors have also chosen to jointly submit their package to the Journal of Open Source Software, so this package includes a short `paper.md` manuscript describing the software that we ask you include in your review.}
+
+Are you able to review? If you can not, suggestions for alternate reviewers are always helpful. Thank you for your time.
+
+Sincerely,
+
+[EDITOR]
+
+[reviewers guide]: https://github.com/ropensci/onboarding/blob/master/reviewing_guide.md
+[packaging guide]: https://github.com/ropensci/onboarding/blob/master/packaging_guide.md 
+[template]: https://github.com/ropensci/onboarding/blob/master/reviewer_template.md 
+[[rOpenSci forum]: https://discuss.ropensci.org/

--- a/reviewer_template.md
+++ b/reviewer_template.md
@@ -1,0 +1,41 @@
+## Package Review
+
+*Please check off boxes as applicable, and elaborate in comments below.  Your review is not limited to these topics, as described in the reviewer guide*
+
+- [ ] As the reviewer I confirm that there are no conflicts of interest for me to review this work (such as being a major contributor to the software).
+
+#### Documentation
+
+The package includes all the following forms of documentation:
+
+- [ ] **A statement of need** clearly stating problems the software is designed to solve and its target audience in README
+- [ ] **Installation instructions:** for the development version of package and any non-standard dependencies in README
+- [ ] **Vignette(s)** demonstrating major functionality that runs successfully locally
+- [ ] **Function Documentation:** for all exported functions in R help
+- [ ] **Examples** for all exported functions in R Help that run successfully locally
+- [ ] **Community guidelines** including contribution guidelines in the README or CONTRIBUTING, and `URL`, `Maintainer` and `BugReports` fields in DESCRIPTION 
+
+>##### Paper (for packages co-submitting to JOSS)
+>
+>The package contains a `paper.md` with:
+>
+>- [ ] **A short summary** describing the high-level functionality of the software
+>- [ ] **Authors:**  A list of authors with their affiliations
+>- [ ] **A statement of need** clearly staing problems the software is designed to solve and its target audience.
+>- [ ] **References:** with DOIs for all those that have one (e.g. papers, datasets, software).
+
+#### Functionality
+
+- [ ] **Installation:** Installation succeeds as documented.
+- [ ] **Functionality:** Any functional claims of the software been confirmed.
+- [ ] **Performance:** Any performance claims of the software been confirmed.
+- [ ] **Automated tests:** Unit tests cover essential functions of the package
+   and a reasonable range of inputs and conditions. All tests pass on the local machine.
+- [ ] **Packaging guidelines**: The package conforms to the rOpenSci packaging guidelines
+
+Estimated hours spent reviewing: 
+
+---
+
+### Review Comments
+

--- a/reviewer_template.md
+++ b/reviewer_template.md
@@ -1,4 +1,4 @@
-### Package Review
+## Package Review
 
 *Please check off boxes as applicable, and elaborate in comments below.  Your review is not limited to these topics, as described in the reviewer guide*
 
@@ -37,5 +37,5 @@ Estimated hours spent reviewing:
 
 ---
 
-#### Review Comments
+### Review Comments
 

--- a/reviewer_template.md
+++ b/reviewer_template.md
@@ -1,4 +1,4 @@
-## Package Review
+### Package Review
 
 *Please check off boxes as applicable, and elaborate in comments below.  Your review is not limited to these topics, as described in the reviewer guide*
 
@@ -37,5 +37,5 @@ Estimated hours spent reviewing:
 
 ---
 
-### Review Comments
+#### Review Comments
 

--- a/reviewing_guide.md
+++ b/reviewing_guide.md
@@ -22,7 +22,8 @@ We encourage you to ask questions and provide feedback on the review process on 
 
 - When your review is complete, paste it as a comment into the package onboarding issue.
 - Please strive to complete your review within 3 weeks of accepting a review request.
-- Comments are welcome in the same issue as a package onboarding request. If your review comments come as a series of issues (perhaps connected to a milestone), please submit those directly to the authors' repository and make a note in the review issue. We hope that package reviews will work as an ongoing conversation with the authors as opposed to a single round of reviews typical of manuscripts.
+- Additional comments are welcome in the same issue as a package onboarding request. We hope that package reviews will work as an ongoing conversation with the authors as opposed to a single round of reviews typical of manuscripts.
+- You may also submit issues or pull requests directly to the package repo if you choose, but if you do, please link to them in the onboarding repo comment thread so we have a centralized record of your review.
 - Please include an estimate of how many hours you spent on your review at the end of your review.
 
 ## Review follow-up

--- a/reviewing_guide.md
+++ b/reviewing_guide.md
@@ -1,12 +1,10 @@
-Reviewers should refer to the [Mozilla reviewing guide](https://mozillascience.github.io/codeReview/review.html) for general principles of review.  [This post](https://github.com/thoughtbot/guides/tree/master/code-review) is also useful.
+# rOpenSci Package Reviewing Guide
 
-We encourage you to ask questions and provide feedback on the review process on our [forum](https://discuss.ropensci.org). 
+To review a package, please begin by copying our [reviewer template](reviewer_template.md)
+and using it as a high-level checklist.  In addition to checking off the minimum criteria,
+we ask you provide general comments addressing the following:
 
-First time reviewers may find it helpful to read some previous reviews.  Here are reviews of [**rusda**](https://github.com/ropensci/onboarding/issues/18), [**textreuse**](https://github.com/ropensci/onboarding/issues/20), and [**Ropenaq**](https://github.com/ropensci/onboarding/issues/24).
-
-# General Review criteria
-
--   Does the code comply with general principles in the [Mozilla reviewing guide](https://mozillascience.github.io/codeReview/review.html)?
+- Does the code comply with general principles in the [Mozilla reviewing guide](https://mozillascience.github.io/codeReview/review.html)?
 - Does the package comply with the [ROpenSci packaging guide](https://github.com/ropensci/packaging_guide)?
 - Are there improvements that could be made to the code style?
 - Is there code duplication in the package that should be reduced?
@@ -14,15 +12,15 @@ First time reviewers may find it helpful to read some previous reviews.  Here ar
 - Are there performance improvements that could be made?
 - Is the documentation (installation instructions/vignettes/examples/demos) clear and sufficient?
 
-_Also ensure that_  
--  tests pass for you locally.
--  vignettes, README, and documentation examples run without issues.
--  and last but not least, please be respectful and kind to the authors
-   in your reviews. Our [code of conduct](policies.md#code-of-conduct) is
-   mandatory for everyone involved in our review process.
+Please be respectful and kind to the authors in your reviews. Our [code of conduct](policies.md#code-of-conduct) is mandatory for everyone involved in our review process.
 
-## Submitting the review
+First time reviewers may find it helpful to read some previous reviews.  Here are reviews of [**rusda**](https://github.com/ropensci/onboarding/issues/18), [**textreuse**](https://github.com/ropensci/onboarding/issues/20), and [**Ropenaq**](https://github.com/ropensci/onboarding/issues/24).
 
+We encourage you to ask questions and provide feedback on the review process on our [forum](https://discuss.ropensci.org). 
+
+## Submitting the Review
+
+- When your review is complete, paste it as a comment into the package onboarding issue.
 - Please strive to complete your review within 3 weeks of accepting a review request.
-- Comments are welcome in the same issue as a package onboarding request. If your review comes as a series of issues (perhaps connected to a milestone), please submit those directly to the authors' repository and make a note in the review issue. We hope that package reviews will work as an ongoing conversation with the authors as opposed to a single round of reviews typical of manuscripts.
+- Comments are welcome in the same issue as a package onboarding request. If your review comments come as a series of issues (perhaps connected to a milestone), please submit those directly to the authors' repository and make a note in the review issue. We hope that package reviews will work as an ongoing conversation with the authors as opposed to a single round of reviews typical of manuscripts.
 - Please include an estimate of how many hours you spent on your review at the end of your review.

--- a/reviewing_guide.md
+++ b/reviewing_guide.md
@@ -24,3 +24,11 @@ We encourage you to ask questions and provide feedback on the review process on 
 - Please strive to complete your review within 3 weeks of accepting a review request.
 - Comments are welcome in the same issue as a package onboarding request. If your review comments come as a series of issues (perhaps connected to a milestone), please submit those directly to the authors' repository and make a note in the review issue. We hope that package reviews will work as an ongoing conversation with the authors as opposed to a single round of reviews typical of manuscripts.
 - Please include an estimate of how many hours you spent on your review at the end of your review.
+
+## Review follow-up
+
+Authors should respond to the review within 2 weeks with their changes to the package
+in response to your review.  At this stage, we ask that you respond as to whether
+the change sufficiently address any issues raised in your review. We encourage
+ongoing discussion between package authors and reviewers, and you may ask editors
+to clarify issues in the review thread, as well.


### PR DESCRIPTION
This PR contains an updated submission template, as well as checklist templates for editors and reviewers.  Collectively the idea here is that the checklists will exceed the JOSS requirements, and that a JOSS editor can approve a package by quickly scanning the RO onboarding review.

There is still more documentation to add, and I don't intend to merge until after a discussion on the forum.