### PR TITLE
Remove duplicate items in packaging_guide.md

### DIFF
--- a/packaging_guide.md
+++ b/packaging_guide.md
@@ -130,10 +130,6 @@ The `DESCRIPTION` file of a package should list package authors and contributors
 Only include reviewers after asking for their consent.
 
 ## <a href="#testing" name="testing"></a> Testing
- 
-* All packages should pass R CMD check/devtools::check() on all major platforms.
-
-* All packages should have a test suite that covers major functionality of the package.
 
 * All packages should pass `R CMD check`/`devtools::check()` on all major platforms.
 


### PR DESCRIPTION
Hello,

This removes two duplicate list items in the packaging guide; they are listed again directly after the removed lines.

Thanks,
Chris