### PR TITLE
Correct typo in issue_template.md

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -33,7 +33,7 @@ Confirm each of the following by checking the box.  This package:
 - [ ] includes documentation with examples for all functions.
 - [ ] contains a vignette with examples of its essential functions and uses.
 - [ ] has a test suite.
-- [ ] has continuous integration, including reporting of test coverage, using services such as Travis CI, Coeveralls and/or CodeCov.
+- [ ] has continuous integration, including reporting of test coverage, using services such as Travis CI, Coveralls and/or CodeCov.
 - [ ] I agree to abide by [ROpenSci's Code of Conduct](https://github.com/ropensci/onboarding/blob/master/policies.md#code-of-conduct) during the review process and in maintaining my package should it be accepted.
 
 #### Publication options


### PR DESCRIPTION
Just correcting a typo I noticed while working on a submission (Coeveralls instead of Coveralls).