### PR TITLE
Reccommend submittal before CRAN

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -88,8 +88,8 @@ information and areas or expertise. We
     -   If you choose this option you should *not* submit your package
         to JOSS separately. It will be evaluated by JOSS based on the rOpenSci review.
 -   We strongly suggest submitting your package for review _before_ publishing
-    on CRAN, as the review feedback may result in major changes to your package,
-    including breaking changes to your function usage.
+    on CRAN, as the review feedback may result in major improvements and updates to your package,
+    including renaming and breaking changes to functions.
 -   Next, [open a new issue](https://github.com/ropensci/onboarding/issues/new) in
 this repository and fill out the template.
 -   An [editor](#editors) will review your submission within 5 business

--- a/README.Rmd
+++ b/README.Rmd
@@ -87,6 +87,9 @@ information and areas or expertise. We
         file describing the package. More detail on JOSS's requirements can be found [at their website](http://joss.theoj.org/about#author_guidelines).
     -   If you choose this option you should *not* submit your package
         to JOSS separately. It will be evaluated by JOSS based on the rOpenSci review.
+-   We strongly suggest submitting your package for review _before_ publishing
+    on CRAN, as the review feedback may result in major changes to your package,
+    including breaking changes to your function usage.
 -   Next, [open a new issue](https://github.com/ropensci/onboarding/issues/new) in
 this repository and fill out the template.
 -   An [editor](#editors) will review your submission within 5 business

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Thank you for considering submitting your package to the rOpenSci suite. All our
 -   Follow our [packaging style guide](packaging_guide.md) to ensure your package meets our style and quality criteria.
     -   If you would like your package also submitted to [Journal of Open-Source Software](http://joss.theoj.org/) (JOSS), it should include a `paper.md` file describing the package. More detail on JOSS's requirements can be found [at their website](http://joss.theoj.org/about#author_guidelines).
     -   If you choose this option you should *not* submit your package to JOSS separately. It will be evaluated by JOSS based on the rOpenSci review.
--   We strongly suggest submitting your package for review *before* publishing on CRAN, as the review feedback may result in major changes to your package, including breaking changes to your function usage.
+-   We strongly suggest submitting your package for review _before_ publishing
+    on CRAN, as the review feedback may result in major improvements and updates to your package,
+    including renaming and breaking changes to functions.
 -   Next, [open a new issue](https://github.com/ropensci/onboarding/issues/new) in this repository and fill out the template.
 -   An [editor](#editors) will review your submission within 5 business days and respond with next steps. The editor may assign the package to reviewers, request that the package be updated to meet minimal criteria before review, or reject the package due to lack of fit or overlap.
 -   If your package meets minimal criteria, the editor will assign 1-3 reviewers. They will be asked to provide reviews as comments on your issue within 3 weeks.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Thank you for considering submitting your package to the rOpenSci suite. All our
 -   Follow our [packaging style guide](packaging_guide.md) to ensure your package meets our style and quality criteria.
     -   If you would like your package also submitted to [Journal of Open-Source Software](http://joss.theoj.org/) (JOSS), it should include a `paper.md` file describing the package. More detail on JOSS's requirements can be found [at their website](http://joss.theoj.org/about#author_guidelines).
     -   If you choose this option you should *not* submit your package to JOSS separately. It will be evaluated by JOSS based on the rOpenSci review.
+-   We strongly suggest submitting your package for review *before* publishing on CRAN, as the review feedback may result in major changes to your package, including breaking changes to your function usage.
 -   Next, [open a new issue](https://github.com/ropensci/onboarding/issues/new) in this repository and fill out the template.
 -   An [editor](#editors) will review your submission within 5 business days and respond with next steps. The editor may assign the package to reviewers, request that the package be updated to meet minimal criteria before review, or reject the package due to lack of fit or overlap.
 -   If your package meets minimal criteria, the editor will assign 1-3 reviewers. They will be asked to provide reviews as comments on your issue within 3 weeks.


### PR DESCRIPTION
Following the conversation on Slack about submittal, I think it makes sense to have language encouraging submission before CRAN.  This will probably end up in the bookdown book, too but it makes sense to try to make this language as visible as possible, so submitters don't just encounter it _on submittal_.  Not sure where/how else to help make it clear.