### PR TITLE
Update links to JOSS author guidelines

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -40,8 +40,8 @@ Confirm each of the following by checking the box.  This package:
 
 - [ ] Do you intend for this package to go on CRAN?  
 - [ ] Do you wish to automatically submit to the [Journal of Open Source Software](http://joss.theoj.org/)? If so:
-    - [ ] The package has an **obvious research application** according to [JOSS's definition](http://joss.theoj.org/about#submission_requirements).
-    - [ ] The package contains a `paper.md` matching [JOSS's requirements](http://joss.theoj.org/about#paper_structure) with a high-level description in the package root or in `inst/`.
+    - [ ] The package has an **obvious research application** according to [JOSS's definition](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements).
+    - [ ] The package contains a `paper.md` matching [JOSS's requirements](https://joss.readthedocs.io/en/latest/submitting.html#what-should-my-paper-contain) with a high-level description in the package root or in `inst/`.
     - [ ] The package is deposited in a long-term repository with the DOI: 
     - (*Do not submit your package separately to JOSS*)
 - [ ] Do you wish to submit an Applications Article about your package to [Methods in Ecology and Evolution](http://besjournals.onlinelibrary.wiley.com/hub/journal/10.1111/(ISSN)2041-210X/)? If so:


### PR DESCRIPTION
JOSS has moved their documentation to readthedocs. The current links now direct to a page that doesn't address what the user would expect. This PR fixes this.